### PR TITLE
棄却されるrememberの値をViewModelに移行

### DIFF
--- a/app/src/main/java/com/oukoda/svinfocompose/model/viewmodel/ListPageViewModel.kt
+++ b/app/src/main/java/com/oukoda/svinfocompose/model/viewmodel/ListPageViewModel.kt
@@ -15,11 +15,15 @@ import kotlinx.coroutines.flow.stateIn
 class ListPageViewModel(private val pokemonList: List<Pokemon>) : ViewModel() {
 
     private var selectedPokemon: Pokemon? = null
-    private var isAscending: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    var isAscending: MutableStateFlow<Boolean> = MutableStateFlow(true)
     var searchWord: MutableStateFlow<String> = MutableStateFlow("")
     var sortType: MutableStateFlow<SortType> = MutableStateFlow(SortType.Number)
 
-    val showPokemonList: StateFlow<List<Pokemon>> = combine(sortType, isAscending, searchWord) { sortType: SortType, isAscending: Boolean, searchWord: String ->
+    val showPokemonList: StateFlow<List<Pokemon>> = combine(
+        sortType,
+        isAscending,
+        searchWord,
+    ) { sortType: SortType, isAscending: Boolean, searchWord: String ->
         var newList = when (sortType) {
             SortType.Number -> pokemonList
             SortType.HP -> pokemonList.sortedBy { it.hp }

--- a/app/src/main/java/com/oukoda/svinfocompose/util/Hira2KanaConverter.kt
+++ b/app/src/main/java/com/oukoda/svinfocompose/util/Hira2KanaConverter.kt
@@ -3,6 +3,10 @@ package com.oukoda.svinfocompose.util
 class Hira2KanaConverter {
     companion object {
         private val HIRAGANA_REGEX = "[\u3040-\u309F]".toRegex()
+        private val KATAKANA_REGEX = "[\u30A0-\u30FF]".toRegex()
+
+        // ひらがなをカタカナに変換する。
+        // ひらがな以外はそのままにする
         fun convert(input: String): String {
             return input.map {
                 if (HIRAGANA_REGEX.matches(it.toString())) {
@@ -11,6 +15,13 @@ class Hira2KanaConverter {
                     it
                 }
             }.joinToString(separator = "")
+        }
+
+        // カタカナの文字だけ抽出する
+        fun hiraKataFilter(input: String): String {
+            return input.filter {
+                KATAKANA_REGEX.matches(it.toString()) || HIRAGANA_REGEX.matches(it.toString())
+            }
         }
     }
 }

--- a/app/src/main/java/com/oukoda/svinfocompose/util/Hira2KanaConverter.kt
+++ b/app/src/main/java/com/oukoda/svinfocompose/util/Hira2KanaConverter.kt
@@ -1,0 +1,16 @@
+package com.oukoda.svinfocompose.util
+
+class Hira2KanaConverter {
+    companion object {
+        private val HIRAGANA_REGEX = "[\u3040-\u309F]".toRegex()
+        fun convert(input: String): String {
+            return input.map {
+                if (HIRAGANA_REGEX.matches(it.toString())) {
+                    it.plus(0x60)
+                } else {
+                    it
+                }
+            }.joinToString(separator = "")
+        }
+    }
+}

--- a/app/src/main/java/com/oukoda/svinfocompose/view/component/listpage/SearchTextField.kt
+++ b/app/src/main/java/com/oukoda/svinfocompose/view/component/listpage/SearchTextField.kt
@@ -1,0 +1,30 @@
+package com.oukoda.svinfocompose.view.component.listpage
+
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.oukoda.svinfocompose.R
+import com.oukoda.svinfocompose.util.Hira2KanaConverter
+
+@Composable
+fun SearchTextField(
+    searchWord: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextField(
+        modifier = modifier,
+        value = searchWord,
+        label = { Text(stringResource(id = R.string.search_text_field_label)) },
+        onValueChange = {
+            val newInputText = Hira2KanaConverter.hiraKataFilter(it)
+            if (searchWord != newInputText) {
+                onValueChange(newInputText)
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/oukoda/svinfocompose/view/component/listpage/SortView.kt
+++ b/app/src/main/java/com/oukoda/svinfocompose/view/component/listpage/SortView.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,20 +22,13 @@ import com.oukoda.svinfocompose.model.enumclass.SortType
 
 @Composable
 fun SortView(
-    initialSortType: SortType,
+    sortType: SortType,
+    isAscending: Boolean,
     onSelectSortType: (sortType: SortType) -> Unit,
     onChangeSortMode: (isAscending: Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var sortType by rememberSaveable {
-        mutableStateOf(initialSortType)
-    }
-
-    var isExpand by remember {
-        mutableStateOf(false)
-    }
-
-    var isChecked by remember {
+    var isSelectTileExpand by remember {
         mutableStateOf(false)
     }
 
@@ -51,7 +43,7 @@ fun SortView(
                 )
             },
             onClick = {
-                isExpand = !isExpand
+                isSelectTileExpand = !isSelectTileExpand
             },
         )
 
@@ -61,27 +53,25 @@ fun SortView(
         ) {
             Text(text = "降順にする")
             Switch(
-                checked = isChecked,
+                checked = !isAscending,
                 onCheckedChange = {
-                    isChecked = it
-                    onChangeSortMode(!isChecked)
+                    onChangeSortMode(!isAscending)
                 },
             )
         }
     }
 
     DropdownMenu(
-        expanded = isExpand,
+        expanded = isSelectTileExpand,
         onDismissRequest = {
-            isExpand = false
+            isSelectTileExpand = false
         },
     ) {
         SortType.values().forEachIndexed { _, itemValue ->
             DropdownMenuItem(
                 onClick = {
-                    sortType = itemValue
                     onSelectSortType(itemValue)
-                    isExpand = false
+                    isSelectTileExpand = false
                 },
             ) {
                 Text(text = stringResource(id = itemValue.stringId))

--- a/app/src/main/java/com/oukoda/svinfocompose/view/component/listpage/SortView.kt
+++ b/app/src/main/java/com/oukoda/svinfocompose/view/component/listpage/SortView.kt
@@ -1,7 +1,6 @@
 package com.oukoda.svinfocompose.view.component.listpage
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
@@ -42,48 +41,50 @@ fun SortView(
     }
 
     Box(modifier = modifier) {
-        Column(horizontalAlignment = Alignment.End) {
-            ExtendedFloatingActionButton(
-                text = { Text(text = stringResource(id = sortType.stringId)) },
-                icon = {
-                    Icon(
-                        painter = painterResource(id = R.drawable.sort),
-                        contentDescription = "",
-                    )
-                },
-                onClick = {
-                    isExpand = !isExpand
+        ExtendedFloatingActionButton(
+            modifier = Modifier.align(Alignment.CenterStart),
+            text = { Text(text = stringResource(id = sortType.stringId)) },
+            icon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.sort),
+                    contentDescription = "",
+                )
+            },
+            onClick = {
+                isExpand = !isExpand
+            },
+        )
+
+        Row(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = "降順にする")
+            Switch(
+                checked = isChecked,
+                onCheckedChange = {
+                    isChecked = it
+                    onChangeSortMode(!isChecked)
                 },
             )
-
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(text = "降順にする")
-                Switch(
-                    checked = isChecked,
-                    onCheckedChange = {
-                        isChecked = it
-                        onChangeSortMode(!isChecked)
-                    },
-                )
-            }
         }
+    }
 
-        DropdownMenu(
-            expanded = isExpand,
-            onDismissRequest = {
-                isExpand = false
-            },
-        ) {
-            SortType.values().forEachIndexed { _, itemValue ->
-                DropdownMenuItem(
-                    onClick = {
-                        sortType = itemValue
-                        onSelectSortType(itemValue)
-                        isExpand = false
-                    },
-                ) {
-                    Text(text = stringResource(id = itemValue.stringId))
-                }
+    DropdownMenu(
+        expanded = isExpand,
+        onDismissRequest = {
+            isExpand = false
+        },
+    ) {
+        SortType.values().forEachIndexed { _, itemValue ->
+            DropdownMenuItem(
+                onClick = {
+                    sortType = itemValue
+                    onSelectSortType(itemValue)
+                    isExpand = false
+                },
+            ) {
+                Text(text = stringResource(id = itemValue.stringId))
             }
         }
     }

--- a/app/src/main/java/com/oukoda/svinfocompose/view/page/ListPage.kt
+++ b/app/src/main/java/com/oukoda/svinfocompose/view/page/ListPage.kt
@@ -19,7 +19,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.oukoda.svinfocompose.model.enumclass.BottomItems
-import com.oukoda.svinfocompose.model.enumclass.SortType
 import com.oukoda.svinfocompose.model.rememberForeverLazyListState
 import com.oukoda.svinfocompose.model.viewmodel.ListPageViewModel
 import com.oukoda.svinfocompose.repository.JsonRepository
@@ -40,6 +39,7 @@ fun ListPage(
 ) {
     val pokemonList by viewModel.showPokemonList.collectAsState()
     val sortType by viewModel.sortType.collectAsState()
+    val isAscending by viewModel.isAscending.collectAsState()
     val searchWord by viewModel.searchWord.collectAsState()
     val navController = rememberNavController()
 
@@ -65,7 +65,8 @@ fun ListPage(
                     ) {
                         Box(modifier = Modifier.padding(vertical = 8.dp)) {
                             SortView(
-                                initialSortType = SortType.Number,
+                                sortType = sortType,
+                                isAscending = isAscending,
                                 onSelectSortType = { viewModel.setSort(it) },
                                 onChangeSortMode = { viewModel.setSortMode(it) },
                                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/oukoda/svinfocompose/view/page/ListPage.kt
+++ b/app/src/main/java/com/oukoda/svinfocompose/view/page/ListPage.kt
@@ -8,10 +8,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -25,6 +25,7 @@ import com.oukoda.svinfocompose.model.viewmodel.ListPageViewModel
 import com.oukoda.svinfocompose.repository.JsonRepository
 import com.oukoda.svinfocompose.view.component.ListItemView
 import com.oukoda.svinfocompose.view.component.listpage.DescriptionView
+import com.oukoda.svinfocompose.view.component.listpage.SearchTextField
 import com.oukoda.svinfocompose.view.component.listpage.SortView
 
 private const val ROUTE_LIST = "list"
@@ -39,6 +40,7 @@ fun ListPage(
 ) {
     val pokemonList by viewModel.showPokemonList.collectAsState()
     val sortType by viewModel.sortType.collectAsState()
+    val searchWord by viewModel.searchWord.collectAsState()
     val navController = rememberNavController()
 
     NavHost(navController = navController, startDestination = ROUTE_LIST) {
@@ -50,13 +52,25 @@ fun ListPage(
             ) {
                 item { Spacer(modifier = Modifier.height(16.dp)) }
                 item {
-                    Box(modifier = Modifier.fillMaxWidth()) {
-                        SortView(
-                            initialSortType = SortType.Number,
-                            onSelectSortType = { viewModel.sort(it) },
-                            onChangeSortMode = { viewModel.setSortMode(it) },
-                            modifier = Modifier.align(Alignment.CenterEnd),
-                        )
+                    SearchTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        searchWord = searchWord,
+                        onValueChange = { viewModel.setSearchWord(it) },
+                    )
+                }
+                item {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                    ) {
+                        Box(modifier = Modifier.padding(vertical = 8.dp)) {
+                            SortView(
+                                initialSortType = SortType.Number,
+                                onSelectSortType = { viewModel.setSort(it) },
+                                onChangeSortMode = { viewModel.setSortMode(it) },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
                     }
                 }
                 itemsIndexed(pokemonList) { _, pokemon ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,4 +52,6 @@
     <string name="sort_type_sp_defence">特防順</string>
     <string name="sort_type_speed">素早さ順</string>
 
+    <string name="search_text_field_label">検索</string>
+
 </resources>

--- a/app/src/test/java/com/oukoda/svinfocompose/model/dataclass/Hira2KataConverterTest.kt
+++ b/app/src/test/java/com/oukoda/svinfocompose/model/dataclass/Hira2KataConverterTest.kt
@@ -1,0 +1,109 @@
+package com.oukoda.svinfocompose.model.dataclass
+
+import com.oukoda.svinfocompose.util.Hira2KanaConverter
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@Suppress("NonAsciiCharacters", "TestFunctionName")
+class Hira2KataConverterTest {
+    @Test
+    fun test_ひらがな一文字が変換できること() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("あ", "ア"),
+            Pair("い", "イ"),
+            Pair("う", "ウ"),
+            Pair("え", "エ"),
+            Pair("お", "オ"),
+            Pair("か", "カ"),
+            Pair("き", "キ"),
+            Pair("く", "ク"),
+            Pair("け", "ケ"),
+            Pair("こ", "コ"),
+            Pair("さ", "サ"),
+            Pair("し", "シ"),
+            Pair("す", "ス"),
+            Pair("せ", "セ"),
+            Pair("そ", "ソ"),
+        )
+        testTaskList.forEach { testTask ->
+            convertTest(testTask.first, testTask.second)
+        }
+    }
+
+    @Test
+    fun test_小文字の一文字が変換できること() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("ぁ", "ァ"),
+            Pair("ぃ", "ィ"),
+            Pair("ぅ", "ゥ"),
+            Pair("ぇ", "ェ"),
+            Pair("ぉ", "ォ"),
+            Pair("っ", "ッ"),
+            Pair("ゃ", "ャ"),
+            Pair("ゅ", "ュ"),
+            Pair("ょ", "ョ"),
+        )
+        testTaskList.forEach { testTask ->
+            convertTest(testTask.first, testTask.second)
+        }
+    }
+
+    @Test
+    fun test_複数文字のひらがなが変換されること() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("うそっきー", "ウソッキー"),
+            Pair("げんがー", "ゲンガー"),
+            Pair("がぶりあす", "ガブリアス"),
+            Pair("ぎゃらどす", "ギャラドス"),
+        )
+        testTaskList.forEach { testTask ->
+            convertTest(testTask.first, testTask.second)
+        }
+    }
+
+    @Test
+    fun test_カタカナが変換されないこと() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("ア", "ア"),
+            Pair("イ", "イ"),
+            Pair("ウ", "ウ"),
+            Pair("エ", "エ"),
+            Pair("オ", "オ"),
+            Pair("ァ", "ァ"),
+        )
+        testTaskList.forEach { testTask ->
+            convertTest(testTask.first, testTask.second)
+        }
+    }
+
+    @Test
+    fun test_ひらがなのみが変換されること() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("ガブリあす", "ガブリアス"),
+            Pair("ふしギダネ", "フシギダネ"),
+            Pair("りザーどン", "リザードン"),
+            Pair("ミずゴろウ", "ミズゴロウ"),
+            Pair("半分、青い", "半分、青イ"),
+        )
+        testTaskList.forEach { testTask ->
+            convertTest(testTask.first, testTask.second)
+        }
+    }
+
+    @Test
+    fun test_漢字が変換されないこと() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("勇気凛凛", "勇気凛凛"),
+            Pair("元気溌剌", "元気溌剌"),
+            Pair("興味津々", "興味津々"),
+            Pair("意気揚々", "意気揚々"),
+        )
+        testTaskList.forEach { testTask ->
+            convertTest(testTask.first, testTask.second)
+        }
+    }
+
+    private fun convertTest(input: String, expected: String) {
+        assertEquals(expected, Hira2KanaConverter.convert(input))
+    }
+}

--- a/app/src/test/java/com/oukoda/svinfocompose/util/Hira2KataConverterTest.kt
+++ b/app/src/test/java/com/oukoda/svinfocompose/util/Hira2KataConverterTest.kt
@@ -1,6 +1,5 @@
-package com.oukoda.svinfocompose.model.dataclass
+package com.oukoda.svinfocompose.util
 
-import com.oukoda.svinfocompose.util.Hira2KanaConverter
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -105,5 +104,44 @@ class Hira2KataConverterTest {
 
     private fun convertTest(input: String, expected: String) {
         assertEquals(expected, Hira2KanaConverter.convert(input))
+    }
+
+    @Test
+    fun test_カタカナがフィルタを通過すること() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("ガブリアス", "ガブリアス"),
+            Pair("ゼニガメ", "ゼニガメ"),
+            Pair("ヒトカゲ", "ヒトカゲ"),
+        )
+        testTaskList.forEach {
+            filterTest(it.first, it.second)
+        }
+    }
+
+    @Test
+    fun test_ひらがながフィルタを通過すること() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("がぶりあす", "がぶりあす"),
+            Pair("ぜにがめ", "ぜにがめ"),
+        )
+        testTaskList.forEach {
+            filterTest(it.first, it.second)
+        }
+    }
+
+    @Test
+    fun test_漢字がフィルタされること() {
+        val testTaskList: List<Pair<String, String>> = listOf(
+            Pair("古今トウザイ", "トウザイ"),
+            Pair("きそう天外", "きそう"),
+            Pair("抱フクゼッ倒", "フクゼッ"),
+        )
+        testTaskList.forEach {
+            filterTest(it.first, it.second)
+        }
+    }
+
+    private fun filterTest(input: String, expected: String) {
+        assertEquals(Hira2KanaConverter.hiraKataFilter(input), expected)
     }
 }


### PR DESCRIPTION
## 実装内容の概要
<!-- このプルリクエストの概要を書いてください --> 
rememberの値が画面遷移によって捨てられる
これにより、詳細画面を開いたあと、一覧画面を確認すると、
並び順などがリセットされてしまう。

## 確認内容
<!-- 動作確認した内容を書いてください -->
- [x] ktlint
- [x] testDebugUnitTest
- [x] connectedAndroidTest
## 補足
<!-- 何かあれば -->